### PR TITLE
Debugged PID class, now using for all 3 pid loops

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,19 @@
+{
+    "configurations": [
+        {
+            "name": "Mac",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "macFrameworkPath": [
+                "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/System/Library/Frameworks"
+            ],
+            "compilerPath": "/usr/bin/clang",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "intelliSenseMode": "macos-clang-x64"
+        }
+    ],
+    "version": 4
+}


### PR DESCRIPTION
"SPID" class now works and brake, gas, and cruise loops are using it. Tested using the hotrc and simulator, and tuned kp, ki, and kd to workable values for all three loops.

Also added another gauge needle to the LCD bargraph for the sensed PID values, now we can see the target value on the same bargraph as the sensed value, which is far more intuitive. It would be great to make a larger display for each PID showing the sensed value vs. the target value, and also the actuator output alongside, maybe even with P, I, and D influences separately visualized as well.

The simulator touchscreen value editing reversal bug is getting frustrating, need to fix that.